### PR TITLE
feat: Prepare ConfigMap structure for Issue #8

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gbc-app-config # Issue #8 で提案された名前
+data: {} # 将来の設定値のために data フィールドは空で定義 

--- a/k8s/nfs-deployment.yaml
+++ b/k8s/nfs-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         image: nginx:latest
         ports:
         - containerPort: 80
+        envFrom:
+        - configMapRef:
+            name: gbc-app-config
         resources:
           limits:
             cpu: "0.5"


### PR DESCRIPTION
This PR prepares the structure for using ConfigMap to manage application settings, as planned in Issue #8.

**Changes:**
- Created an empty ConfigMap `gbc-app-config` in `k8s/configmap.yaml` as a placeholder for future settings.
- Modified `k8s/nfs-deployment.yaml` to reference this ConfigMap using `envFrom`.

**Note:** No actual settings were migrated as none were found in the target Deployment.

Closes #8