### PR TITLE
ConfigMapとSecretの活用実装

### DIFF
--- a/docs/config-secret-management.md
+++ b/docs/config-secret-management.md
@@ -1,0 +1,181 @@
+# ConfigMapとSecretの管理ガイド
+
+このドキュメントでは、GBC Productにおける設定値と機密情報の管理方法について説明します。
+
+## 目次
+
+1. [概要](#概要)
+2. [ConfigMapの管理](#configmapの管理)
+3. [Secretの管理](#secretの管理)
+4. [環境ごとの設定切り替え](#環境ごとの設定切り替え)
+5. [CI/CDパイプラインでの管理](#cicdパイプラインでの管理)
+6. [参考情報](#参考情報)
+
+## 概要
+
+GBC Productでは以下の原則に基づいて設定管理を行います：
+
+- 非機密設定は**ConfigMap**で管理
+- 機密情報は**Secret**で管理
+- 環境ごとに異なる設定は環境固有のConfigMapとSecretを使用
+
+## ConfigMapの管理
+
+### ConfigMapの構造
+
+プロジェクトには以下の3種類のConfigMapが存在します：
+
+1. **gbc-app-config** (k8s/configmap.yaml): 基本設定
+2. **gbc-app-config-dev** (k8s/configmap-dev.yaml): 開発環境固有の設定
+3. **gbc-app-config-prod** (k8s/configmap-prod.yaml): 本番環境固有の設定
+
+各ConfigMapには以下のカテゴリの設定が含まれています：
+
+- アプリケーション基本設定（ポート番号、ホスト名など）
+- サービス接続設定（タイムアウト、リトライ回数など）
+- システム設定（最大接続数など）
+- 環境設定（環境名、APIエンドポイントなど）
+- HTMLテンプレート用のJSON設定
+
+### ConfigMapの更新方法
+
+ConfigMapを更新する場合は、対応するYAMLファイルを編集し、以下のコマンドで適用します：
+
+```bash
+kubectl apply -f k8s/configmap.yaml
+```
+
+環境固有の設定を一括で適用する場合は、以下のスクリプトを使用します：
+
+```bash
+ENVIRONMENT=dev ./scripts/apply-configs.sh
+# または
+ENVIRONMENT=prod ./scripts/apply-configs.sh
+```
+
+## Secretの管理
+
+### Secretの構造
+
+プロジェクトには以下の3種類のSecretが存在します：
+
+1. **gbc-app-secrets** (k8s/secrets.yaml): 基本機密情報
+2. **gbc-app-secrets-dev** (k8s/secrets-dev.yaml): 開発環境固有の機密情報
+3. **gbc-app-secrets-prod** (k8s/secrets-prod.yaml): 本番環境固有の機密情報
+
+各Secretには以下のカテゴリの機密情報が含まれています：
+
+- データベース接続情報（ホスト、ポート、データベース名、ユーザー名、パスワード）
+- APIキー
+- JWT Secret
+- SSL証明書と秘密鍵
+
+### Secretの更新方法
+
+Secret値の更新には、以下のステップを実施します：
+
+1. 値をbase64エンコードする
+   ```bash
+   echo -n "実際の値" | base64
+   ```
+
+2. エンコードした値をYAMLファイルに記載
+
+3. Secretを適用する
+   ```bash
+   kubectl apply -f k8s/secrets.yaml
+   ```
+
+**注意**: YAMLファイルに直接機密情報を保存することは本番環境では推奨されません。CI/CDパイプラインでの管理方法については後述します。
+
+## 環境ごとの設定切り替え
+
+環境を切り替えるには、以下のスクリプトを使用します：
+
+```bash
+./scripts/switch-environment.sh dev
+# または
+./scripts/switch-environment.sh prod
+```
+
+このスクリプトは、以下の操作を実行します：
+1. 環境固有のConfigMapを適用
+2. 環境固有のSecretを適用
+3. デプロイメントを再起動して新しい設定を適用
+
+## CI/CDパイプラインでの管理
+
+### 推奨アプローチ
+
+本番環境でのSecretの管理には、以下のアプローチを推奨します：
+
+1. **外部シークレット管理システムの利用**
+   - HashiCorp Vault
+   - AWS Secrets Manager
+   - Google Secret Manager
+   - Azure Key Vault
+
+2. **Kubernetes External Secretsの利用**
+   - 外部のシークレット管理システムと連携し、Kubernetes Secretsを自動生成
+
+3. **GitOpsパイプラインでのSecret暗号化**
+   - SOPS (Secrets OPerationS)
+   - Sealed Secrets
+   - Argo CD Vault Plugin
+
+### サンプル実装: SOPSを使用したSecret暗号化
+
+1. SOPSをインストール
+   ```bash
+   # MacOS
+   brew install sops
+   
+   # Linux
+   wget https://github.com/mozilla/sops/releases/download/v3.7.3/sops-v3.7.3.linux.amd64 -O sops
+   chmod +x sops
+   sudo mv sops /usr/local/bin/
+   ```
+
+2. GPGキーで暗号化
+   ```bash
+   # GPGキーを生成
+   gpg --gen-key
+   
+   # キーIDを取得
+   gpg --list-keys
+   
+   # Secretを暗号化
+   sops --encrypt --pgp <キーID> k8s/secrets-prod.yaml > k8s/secrets-prod.enc.yaml
+   ```
+
+3. CI/CDパイプラインでの復号化
+   ```yaml
+   # GitHubActionsサンプル
+   jobs:
+     deploy:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v3
+         
+         - name: Import GPG key
+           uses: crazy-max/ghaction-import-gpg@v5
+           with:
+             gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+             passphrase: ${{ secrets.GPG_PASSPHRASE }}
+         
+         - name: Decrypt secrets
+           run: |
+             sops --decrypt k8s/secrets-prod.enc.yaml > k8s/secrets-prod.yaml
+         
+         - name: Apply resources
+           run: |
+             kubectl apply -f k8s/secrets-prod.yaml
+   ```
+
+## 参考情報
+
+- [Kubernetes ConfigMap公式ドキュメント](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [Kubernetes Secret公式ドキュメント](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [SOPS GitHub](https://github.com/mozilla/sops)
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
+- [Kubernetes External Secrets](https://github.com/external-secrets/external-secrets) 

--- a/k8s/base-deployment.yaml
+++ b/k8s/base-deployment.yaml
@@ -80,6 +80,18 @@ spec:
         - name: db-volume
           persistentVolumeClaim:
             claimName: gbc-app-db-pvc
+        - name: config-volume
+          configMap:
+            name: gbc-app-config
+        # SSL証明書をマウントする場合は以下のコメントを解除
+        # - name: ssl-certs
+        #   secret:
+        #     secretName: gbc-app-secrets
+        #     items:
+        #     - key: SSL_CERT
+        #       path: tls.crt
+        #     - key: SSL_KEY
+        #       path: tls.key
       containers:
       - name: gbc-app
         image: nginx:latest
@@ -97,6 +109,60 @@ spec:
             name: logs-volume
           - mountPath: /app/data
             name: db-volume
+          - mountPath: /app/config
+            name: config-volume
+          # SSL証明書をマウントする場合は以下のコメントを解除
+          # - mountPath: /app/certs
+          #   name: ssl-certs
+          #   readOnly: true
+        env:
+          # ConfigMapから環境変数を設定
+          - name: APP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: gbc-app-config
+                key: APP_PORT
+          - name: APP_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: gbc-app-config
+                key: APP_HOST
+          - name: LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: gbc-app-config
+                key: LOG_LEVEL
+          - name: DEBUG_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: gbc-app-config
+                key: DEBUG_MODE
+          - name: ENVIRONMENT
+            valueFrom:
+              configMapKeyRef:
+                name: gbc-app-config
+                key: ENVIRONMENT
+          # Secretから環境変数を設定
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: gbc-app-secrets
+                key: DB_USERNAME
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: gbc-app-secrets
+                key: DB_PASSWORD
+          - name: API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: gbc-app-secrets
+                key: API_KEY
+          - name: JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: gbc-app-secrets
+                key: JWT_SECRET
         readinessProbe:
           httpGet:
             path: /

--- a/k8s/configmap-dev.yaml
+++ b/k8s/configmap-dev.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gbc-app-config-dev
+  labels:
+    app: gbc-app
+    environment: development
+data:
+  # アプリケーション基本設定
+  APP_PORT: "80"
+  APP_HOST: "0.0.0.0"
+  LOG_LEVEL: "debug"  # 開発環境では詳細なログを出力
+  DEBUG_MODE: "true"  # 開発環境ではデバッグモードを有効化
+  
+  # サービス接続設定
+  SERVICE_TIMEOUT: "60"  # 開発環境では長めのタイムアウト
+  RETRY_COUNT: "5"
+  
+  # システム設定
+  MAX_CONNECTIONS: "50"  # 開発環境では接続数を制限
+  
+  # 環境設定
+  ENVIRONMENT: "development"
+  API_ENDPOINT: "http://api-service.dev"
+  
+  # HTMLテンプレート用の設定
+  app-environment.json: |
+    {
+      "environment": "development",
+      "apiBaseUrl": "http://api-service.dev",
+      "features": {
+        "enableAnalytics": false,
+        "enableNotifications": true,
+        "enableDebugTools": true
+      }
+    } 

--- a/k8s/configmap-prod.yaml
+++ b/k8s/configmap-prod.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gbc-app-config-prod
+  labels:
+    app: gbc-app
+    environment: production
+data:
+  # アプリケーション基本設定
+  APP_PORT: "80"
+  APP_HOST: "0.0.0.0"
+  LOG_LEVEL: "warn"  # 本番環境では警告以上のログのみ出力
+  DEBUG_MODE: "false"  # 本番環境ではデバッグモードを無効化
+  
+  # サービス接続設定
+  SERVICE_TIMEOUT: "30"  # 本番環境では適切なタイムアウト
+  RETRY_COUNT: "3"
+  
+  # システム設定
+  MAX_CONNECTIONS: "500"  # 本番環境では多くの接続を許可
+  
+  # 環境設定
+  ENVIRONMENT: "production"
+  API_ENDPOINT: "https://api.example.com"
+  
+  # HTMLテンプレート用の設定
+  app-environment.json: |
+    {
+      "environment": "production",
+      "apiBaseUrl": "https://api.example.com",
+      "features": {
+        "enableAnalytics": true,
+        "enableNotifications": true,
+        "enableDebugTools": false
+      }
+    } 

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,5 +1,34 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gbc-app-config # Issue #8 で提案された名前
-data: {} # 将来の設定値のために data フィールドは空で定義 
+  name: gbc-app-config
+  labels:
+    app: gbc-app
+data:
+  # アプリケーション基本設定
+  APP_PORT: "80"
+  APP_HOST: "0.0.0.0"
+  LOG_LEVEL: "info"
+  DEBUG_MODE: "false"
+  
+  # サービス接続設定
+  SERVICE_TIMEOUT: "30"
+  RETRY_COUNT: "3"
+  
+  # システム設定
+  MAX_CONNECTIONS: "100"
+  
+  # 環境設定
+  ENVIRONMENT: "development"
+  API_ENDPOINT: "http://api-service"
+  
+  # HTMLテンプレート用の設定
+  app-environment.json: |
+    {
+      "environment": "development",
+      "apiBaseUrl": "http://api-service",
+      "features": {
+        "enableAnalytics": false,
+        "enableNotifications": true
+      }
+    } 

--- a/k8s/secrets-dev.yaml
+++ b/k8s/secrets-dev.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gbc-app-secrets-dev
+  labels:
+    app: gbc-app
+    environment: development
+type: Opaque
+data:
+  # 開発環境用データベース接続情報（base64エンコード済み）
+  DB_HOST: bG9jYWxob3N0  # localhost
+  DB_PORT: MzMwNg==  # 3306
+  DB_NAME: Z2JjX2RldmVsb3BtZW50  # gbc_development
+  DB_USERNAME: ZGV2X3VzZXI=  # dev_user
+  DB_PASSWORD: ZGV2X3Bhc3N3b3Jk  # dev_password
+  
+  # 開発環境用APIキー（base64エンコード済み）
+  API_KEY: ZGV2X2FwaV9rZXlfMTIzNDU=  # dev_api_key_12345
+  
+  # 開発環境用JWT Secret（base64エンコード済み）
+  JWT_SECRET: ZGV2X2p3dF9zZWNyZXRfa2V5  # dev_jwt_secret_key
+  
+  # 開発環境用SSL証明書（base64エンコード済み）
+  # 実際の環境では、本物の証明書と鍵を使用します
+  SSL_CERT: LS0tREVWRUxPUE1FTlQgQ0VSVElGSUNBVEUtLS0=  # ---DEVELOPMENT CERTIFICATE---
+  SSL_KEY: LS0tREVWRUxPUE1FTlQgS0VZLS0t  # ---DEVELOPMENT KEY--- 

--- a/k8s/secrets-prod.yaml
+++ b/k8s/secrets-prod.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gbc-app-secrets-prod
+  labels:
+    app: gbc-app
+    environment: production
+type: Opaque
+data:
+  # 本番環境用データベース接続情報（base64エンコード済み）
+  # 注: 実際の環境では、これらの値は外部のシークレット管理システムから取得するか、
+  # CI/CDパイプラインで注入することをお勧めします
+  DB_HOST: cHJvZC1kYi5leGFtcGxlLmNvbQ==  # prod-db.example.com
+  DB_PORT: MzMwNg==  # 3306
+  DB_NAME: Z2JjX3Byb2R1Y3Rpb24=  # gbc_production
+  DB_USERNAME: cHJvZF91c2Vy  # prod_user
+  DB_PASSWORD: c2VjdXJlX3Byb2RfcGFzc3dvcmQ=  # secure_prod_password
+  
+  # 本番環境用APIキー（base64エンコード済み）
+  API_KEY: cHJvZF9hcGlfa2V5X2FiY2RlZjEyMzQ1Njc4OTA=  # prod_api_key_abcdef1234567890
+  
+  # 本番環境用JWT Secret（base64エンコード済み）
+  JWT_SECRET: cHJvZF9qd3Rfc2VjcmV0X2tleV93aXRoX2hpZ2hfZW50cm9weQ==  # prod_jwt_secret_key_with_high_entropy
+  
+  # 本番環境用SSL証明書（base64エンコード済み）
+  # 実際の環境では、有効な証明書と鍵を使用します
+  SSL_CERT: LS0tUFJPRFVDVElPTiBDRVJUSUZJQ0FURS0tLQ==  # ---PRODUCTION CERTIFICATE---
+  SSL_KEY: LS0tUFJPRFVDVElPTiBLRVktLS0=  # ---PRODUCTION KEY--- 

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gbc-app-secrets
+  labels:
+    app: gbc-app
+type: Opaque
+data:
+  # データベース接続情報（base64エンコード済み）
+  # 注: 実際の環境では、これらの値は外部のシークレット管理システムから取得するか、
+  # CI/CDパイプラインで注入することをお勧めします
+  DB_USERNAME: YWRtaW4=  # admin
+  DB_PASSWORD: cGFzc3dvcmQxMjM=  # password123
+  
+  # APIキー（base64エンコード済み）
+  API_KEY: YWJjZGVmMTIzNDU2Nzg5MA==  # abcdef1234567890
+  
+  # JWT Secret（base64エンコード済み）
+  JWT_SECRET: and0X3NlY3JldF9rZXlfZm9yX2diY19hcHA=  # jwt_secret_key_for_gbc_app 

--- a/scripts/apply-configs.sh
+++ b/scripts/apply-configs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# 環境変数が設定されていない場合は、デフォルトの環境を使用
+ENVIRONMENT=${ENVIRONMENT:-dev}
+
+echo "環境: $ENVIRONMENT を適用します..."
+
+# 共通ConfigMapを適用
+kubectl apply -f k8s/configmap.yaml
+
+# 環境固有のConfigMapを適用
+if [ "$ENVIRONMENT" = "dev" ]; then
+  echo "開発環境用のConfigMapを適用します..."
+  kubectl apply -f k8s/configmap-dev.yaml
+elif [ "$ENVIRONMENT" = "prod" ]; then
+  echo "本番環境用のConfigMapを適用します..."
+  kubectl apply -f k8s/configmap-prod.yaml
+else
+  echo "警告: 未知の環境 '$ENVIRONMENT' が指定されました。デフォルトのConfigMapのみを適用します。"
+fi
+
+# 基本Secretを適用
+kubectl apply -f k8s/secrets.yaml
+
+# 環境固有のSecretを適用
+if [ "$ENVIRONMENT" = "dev" ]; then
+  echo "開発環境用のSecretを適用します..."
+  kubectl apply -f k8s/secrets-dev.yaml
+elif [ "$ENVIRONMENT" = "prod" ]; then
+  echo "本番環境用のSecretを適用します..."
+  kubectl apply -f k8s/secrets-prod.yaml
+else
+  echo "警告: 未知の環境 '$ENVIRONMENT' が指定されました。デフォルトのSecretのみを適用します。"
+fi
+
+# デプロイメントを適用
+echo "デプロイメントを適用します..."
+kubectl apply -f k8s/base-deployment.yaml
+
+echo "完了しました！" 

--- a/scripts/switch-environment.sh
+++ b/scripts/switch-environment.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# 引数が提供されているかチェック
+if [ "$#" -ne 1 ]; then
+    echo "使用方法: $0 [dev|prod]"
+    exit 1
+fi
+
+ENVIRONMENT=$1
+
+# 有効な環境値かチェック
+if [ "$ENVIRONMENT" != "dev" ] && [ "$ENVIRONMENT" != "prod" ]; then
+    echo "エラー: 環境は 'dev' または 'prod' を指定してください"
+    exit 1
+fi
+
+echo "環境を $ENVIRONMENT に切り替えています..."
+
+# 基本ConfigMapと環境固有のConfigMapをマージする
+echo "1. 環境固有のConfigMapを適用..."
+if [ "$ENVIRONMENT" = "dev" ]; then
+    # 開発環境ConfigMapを適用
+    kubectl apply -f k8s/configmap-dev.yaml
+    
+    # 基本ConfigMapを環境固有のConfigMapで更新
+    echo "   基本ConfigMapを開発環境の値で更新..."
+    kubectl get configmap gbc-app-config-dev -o yaml | \
+    sed 's/name: gbc-app-config-dev/name: gbc-app-config/' | \
+    kubectl apply -f -
+else
+    # 本番環境ConfigMapを適用
+    kubectl apply -f k8s/configmap-prod.yaml
+    
+    # 基本ConfigMapを環境固有のConfigMapで更新
+    echo "   基本ConfigMapを本番環境の値で更新..."
+    kubectl get configmap gbc-app-config-prod -o yaml | \
+    sed 's/name: gbc-app-config-prod/name: gbc-app-config/' | \
+    kubectl apply -f -
+fi
+
+# 環境固有のSecretを適用
+echo "2. 環境固有のSecretを適用..."
+if [ "$ENVIRONMENT" = "dev" ]; then
+    kubectl apply -f k8s/secrets-dev.yaml
+    
+    # 基本Secretを環境固有のSecretで更新
+    echo "   基本Secretを開発環境の値で更新..."
+    kubectl get secret gbc-app-secrets-dev -o yaml | \
+    sed 's/name: gbc-app-secrets-dev/name: gbc-app-secrets/' | \
+    kubectl apply -f -
+else
+    kubectl apply -f k8s/secrets-prod.yaml
+    
+    # 基本Secretを環境固有のSecretで更新
+    echo "   基本Secretを本番環境の値で更新..."
+    kubectl get secret gbc-app-secrets-prod -o yaml | \
+    sed 's/name: gbc-app-secrets-prod/name: gbc-app-secrets/' | \
+    kubectl apply -f -
+fi
+
+# デプロイメントを更新して新しい設定を使用するようにする
+echo "3. デプロイメントを再起動して新しい設定を適用..."
+# デプロイメントをロールアウトリスタート
+kubectl rollout restart deployment gbc-app
+
+# ロールアウト完了を待機
+echo "デプロイメントが完了するまで待機しています..."
+kubectl rollout status deployment gbc-app
+
+echo ""
+echo "環境が $ENVIRONMENT に切り替わりました。"
+echo "新しい設定でPodが実行されているか確認するには、scripts/test-configs.sh を実行してください。" 

--- a/scripts/test-configs.sh
+++ b/scripts/test-configs.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# テスト環境変数が設定されていない場合は、デフォルトの環境を使用
+ENVIRONMENT=${ENVIRONMENT:-dev}
+
+echo "環境: $ENVIRONMENT の設定をテストします..."
+
+# Pod名を取得
+POD_NAME=$(kubectl get pods -l app=gbc-app -o jsonpath="{.items[0].metadata.name}")
+
+if [ -z "$POD_NAME" ]; then
+  echo "エラー: gbc-appのPodが見つかりません！"
+  exit 1
+fi
+
+echo "Pod: $POD_NAME を使用してテストを実行します"
+
+# ConfigMapから設定された環境変数をテスト
+echo "1. ConfigMapから設定された環境変数のテスト:"
+echo "--------------------------------------------"
+kubectl exec $POD_NAME -- env | grep APP_PORT
+kubectl exec $POD_NAME -- env | grep APP_HOST
+kubectl exec $POD_NAME -- env | grep LOG_LEVEL
+kubectl exec $POD_NAME -- env | grep DEBUG_MODE
+kubectl exec $POD_NAME -- env | grep ENVIRONMENT
+
+# Secretから設定された環境変数をテスト（値を表示せず存在確認のみ）
+echo ""
+echo "2. Secretから設定された環境変数の存在確認:"
+echo "--------------------------------------------"
+kubectl exec $POD_NAME -- bash -c '[ ! -z "$DB_USERNAME" ] && echo "DB_USERNAME: 設定されています" || echo "DB_USERNAME: 未設定"'
+kubectl exec $POD_NAME -- bash -c '[ ! -z "$DB_PASSWORD" ] && echo "DB_PASSWORD: 設定されています" || echo "DB_PASSWORD: 未設定"'
+kubectl exec $POD_NAME -- bash -c '[ ! -z "$API_KEY" ] && echo "API_KEY: 設定されています" || echo "API_KEY: 未設定"'
+kubectl exec $POD_NAME -- bash -c '[ ! -z "$JWT_SECRET" ] && echo "JWT_SECRET: 設定されています" || echo "JWT_SECRET: 未設定"'
+
+# マウントされたConfigMapファイルの確認
+echo ""
+echo "3. マウントされたConfigMapファイルの確認:"
+echo "--------------------------------------------"
+kubectl exec $POD_NAME -- ls -la /app/config/
+
+# マウントされたSecretファイルの確認
+echo ""
+echo "4. マウントされたSecretファイルの確認:"
+echo "--------------------------------------------"
+kubectl exec $POD_NAME -- ls -la /app/certs/
+
+# ConfigMapの内容確認（JSONファイル）
+echo ""
+echo "5. マウントされたJSONファイルの内容確認:"
+echo "--------------------------------------------"
+kubectl exec $POD_NAME -- cat /app/config/app-environment.json
+
+echo ""
+echo "テスト完了！" 


### PR DESCRIPTION
## 概要
Issue #11「ConfigMapとSecretの活用」のタスクを完了しました。ConfigMapとSecretを使用して、環境変数と機密情報を適切に管理するための仕組みを構築しました。

## 実装内容
- ConfigMapの拡張と環境ごとの設定（development/production）
- Secretマニフェストの作成（開発/本番環境用）
- デプロイメントとの連携設定（環境変数とボリュームマウント）
- 設定適用スクリプトの作成（`scripts/apply-configs.sh`）
- 環境切り替えスクリプトの作成（`scripts/switch-environment.sh`）
- 設定テストスクリプトの作成（`scripts/test-configs.sh`）
- 設定管理ガイドラインのドキュメント作成（`docs/config-secret-management.md`）

## 検証結果
- Kubernetesクラスター上でConfigMapとSecretが正しく動作することを確認
- 環境変数が正しく設定されていることを確認
- ボリュームマウントが正しく機能していることを確認
- 環境切り替えの基本機能を検証（一部課題あり）

## 今後の改善ポイント
- 環境切り替えの仕組みをより堅牢にする
- SSL証明書のマウント機能の完全実装
- 本番環境でのSecret管理のセキュリティ強化

Close #11